### PR TITLE
Added new endpoint and fixed syntax problems fix #11, fix #23

### DIFF
--- a/config.py
+++ b/config.py
@@ -2,15 +2,16 @@ import json
 
 fi = "config.json"
 
+
 def load_settings():
     with open(fi, "rb") as f:
         s = json.load(f)
         return s
     return None
 
+
 def get_setting(key, default=None):
     settings = load_settings()
     if key in settings:
         return settings.get(key, default)
     return default
-    

--- a/flaskr/__init__.py
+++ b/flaskr/__init__.py
@@ -36,29 +36,73 @@ def check_payload(sample, payload):
     Loop through all keys in sample, make sure they all exist in the payload.
     Type check all keys to make sure they match. Lists are harder, since 
     there isn't an implementation to check if the elements are of the correct type.
-    TODO: ADD TYPE CHECKING FOR ELEMENTS IN LISTS
     """
+    # Loop through all keys in sample
     for key in sample:
-        if payload and hasattr(payload, "__iter__"):
-            if key in payload:
-                if type(sample[key]) == list:
-                    # Here we type check for all possible allowed types in the list in the sample object.
+
+        # Make sure that the payload has every single key that the sample does.
+        if key in payload:
+
+            # If the type in the sample is a list, then we have further checking to do.
+            if type(sample[key]) == list:
+
+                # If we have specified the first element in the list to be of 'list:<type>' format, then make 
+                # sure that all elements in the payload on that key is of the type <type>.
+                if "list:" in sample[key][0]:
+                    # Split list specifyer on :, to retrieve which type that is allowed inside.
+                    sp = sample[key][0].split(":")
+
+                    # Type check all elements in the payload against the specified type in the sample
+                    checked = [(type(ele) == eval(sp[1]), ele) for ele in payload[key]]
+
+                    # Get which of the elements in the list that do not satisfy the type check.
+                    checked = [e for ch, e in checked if not ch]
+
+                    # If there were any elements that failed the type check, return ERROR: type check failed.
+                    if len(checked) > 0:
+                        ele = checked.pop()
+                        return False, f"ERROR: On key '{key}', expected element type(s) '{eval(sp[1])}', got {type(ele)} at element {ele}."
+                    # If no elements failed the type check, just keep looping through all keys.
+                    else:
+                        continue
+
+
+                # If the sample value at the key is a list of strings, and weren't list specifiers ^ above case.
+                if type(sample[key][0]) == str:
+
+                    # Get all types which are OK for this key from the sample
                     ok_types = [eval(t) for t in sample[key]]
+
+                    # If the payload's type is not in the OK types list, then return ERROR: failed type check.
                     if not (type(payload[key]) in ok_types):
-                        return False, f"ERROR: On key '{key}', expected type(s) '{ok_types}', got '{type(payload[key])}'."
-                elif type(sample[key]) == str:
-                    # If it is a string in the sample, then that means that the key must match EXACT
-                    if not (sample[key] == payload[key]):
-                        return False, f"ERROR: On key '{key}', expected '{sample[key]}', got '{payload[key]}'."
-                else:
-                    # The sample is an object, recursively check downwards
-                    succ, msg = check_payload(sample[key], payload[key])
-                    if not succ:
-                        return False, msg
+                        return False, f"ERROR: On key '{key}', expected type(s) '{ok_types}', got '{type(payload[key])}'"
+
+
+                # This case is if the sample at the key contains a list of objects
+                elif type(sample[key][0]) == dict:
+                    
+                    # Type check all objects in the list of objects in the payload.
+                    elements_check = [check_payload(sample[key][0], obj) for obj in payload[key]]
+
+                    # Get all objects that failed the type check
+                    failed_payloads = [msg for (succ, msg) in elements_check if not succ]
+
+                    # If the length of failed_payloads is more than 0, then there is at least one that failed.
+                    if len(failed_payloads) > 0: 
+                        return False, failed_payloads.pop()
+                    else:
+                        continue
+            elif type(sample[key]) == str:
+                # If it is a string, then that means that the key must match EXACT
+                if not (sample[key] == payload[key]):
+                    return False, f"ERROR: On key '{key}', expected '{ok_types}', got '{payload[key]}'."
             else:
-                return False, f"ERROR: Missing key '{key}'"
+                # the sample is an object, recurse down
+                succ, msg = check_payload(sample[key], payload[key])
+                if not succ:
+                    return succ, msg
         else:
-            return False, f"ERROR: Payload is null or in wrong format."
+            return False, f"ERROR: Missing key '{key}'"
     return True, "Payload matches sample."
 
 # Here we will import endpoints

--- a/flaskr/__init__.py
+++ b/flaskr/__init__.py
@@ -4,38 +4,31 @@ from flask_cors import CORS
 app = Flask(__name__)
 CORS(app)
 
-# Below is a standard testing one
-# This line specifies at which url you reach this defined method. Also which HTTP methods that can be used with it.
-@app.route('/', methods=["GET"])
-def hello_world(): # The method that is called when accessing the base url /
-    # make_response creates a response with status code and correct headers.
-    # jsonify turns the string "Hello World!" into a json-string.
-    # We give the make_response method a json-string, and a status code, in this case 200 OK.
-    # This response with then be passed to the below method (done automatically by Flask).
-    # Look at comments on below method to understand.
-    return make_response(jsonify("Hello World!"), 200) 
 
-# Send the response in an appropriate format
-# app.after_request is called whenever we return anything to the caller of the API.
-# the response object is the response that make_response returns in all endpoints.
+@app.route('/', methods=["GET"])
+def hello_world():  # The method that is called when accessing the base url /
+    return make_response(jsonify("Hello World!"), 200)
+
+
 @app.after_request
 def after(response):
     # Here we define a static structure for ALL responses by the API.
     # By doing this, we can make sure that all responses are in the same format
     # and all contain the status code of the response.
-	ret = {
-		"status_code": response.status_code, # 200
-		"status": response.status, # 200 OK
-		"response": response.get_json() # json-object
-	}
+    ret = {
+        "status_code": response.status_code,  # 200
+        "status": response.status,  # 200 OK
+        "response": response.get_json()  # json-object
+    }
     # creates the response and returns to the caller.
-	return make_response(jsonify(ret), ret["status_code"])
+    return make_response(jsonify(ret), ret["status_code"])
+
 
 def check_payload(sample, payload):
     """
     Loop through all keys in sample, make sure they all exist in the payload.
-    Type check all keys to make sure they match. Lists are harder, since 
-    there isn't an implementation to check if the elements are of the correct type.
+    Type check all keys to make sure they match. 20201208, there is now
+    a type check for list elements.
     """
     # Loop through all keys in sample
     for key in sample:
@@ -46,8 +39,8 @@ def check_payload(sample, payload):
             # If the type in the sample is a list, then we have further checking to do.
             if type(sample[key]) == list:
 
-                # If we have specified the first element in the list to be of 'list:<type>' format, then make 
-                # sure that all elements in the payload on that key is of the type <type>.
+                # If we have specified the first element in the list to be of 'list:<type>' format, then make sure
+                # that all elements in the payload on that key is of the type <type>.
                 if "list:" in sample[key][0]:
                     # Split list specifyer on :, to retrieve which type that is allowed inside.
                     sp = sample[key][0].split(":")
@@ -61,11 +54,12 @@ def check_payload(sample, payload):
                     # If there were any elements that failed the type check, return ERROR: type check failed.
                     if len(checked) > 0:
                         ele = checked.pop()
-                        return False, f"ERROR: On key '{key}', expected element type(s) '{eval(sp[1])}', got {type(ele)} at element {ele}."
+                        t = type(ele)
+                        s = f"ERROR: On key '{key}', expected element type(s) '{eval(sp[1])}', got {t} at element {ele}."
+                        return False, s
                     # If no elements failed the type check, just keep looping through all keys.
                     else:
                         continue
-
 
                 # If the sample value at the key is a list of strings, and weren't list specifiers ^ above case.
                 if type(sample[key][0]) == str:
@@ -77,10 +71,8 @@ def check_payload(sample, payload):
                     if not (type(payload[key]) in ok_types):
                         return False, f"ERROR: On key '{key}', expected type(s) '{ok_types}', got '{type(payload[key])}'"
 
-
                 # This case is if the sample at the key contains a list of objects
                 elif type(sample[key][0]) == dict:
-                    
                     # Type check all objects in the list of objects in the payload.
                     elements_check = [check_payload(sample[key][0], obj) for obj in payload[key]]
 
@@ -88,7 +80,7 @@ def check_payload(sample, payload):
                     failed_payloads = [msg for (succ, msg) in elements_check if not succ]
 
                     # If the length of failed_payloads is more than 0, then there is at least one that failed.
-                    if len(failed_payloads) > 0: 
+                    if len(failed_payloads) > 0:
                         return False, failed_payloads.pop()
                     else:
                         continue
@@ -104,6 +96,7 @@ def check_payload(sample, payload):
         else:
             return False, f"ERROR: Missing key '{key}'"
     return True, "Payload matches sample."
+
 
 # Here we will import endpoints
 import flaskr.products

--- a/flaskr/bench_util.py
+++ b/flaskr/bench_util.py
@@ -4,6 +4,7 @@ from flaskr import app, check_payload
 from flaskr.db import coll_benchmarks, coll_transports
 import datetime
 import json
+from datetime import datetime as dt
 
 
 # Get chain impact for a specific product id using the latest benchmarks for that product.
@@ -61,6 +62,49 @@ def get_chain_impact(_id):
     return 0
 
 
+# Create a chain impact for the specified benchmark by looping through all sub products.
+def create_chain_impact(benchmark):
+    # Start off with a chain impact that's completely empty
+    chain = {
+        "co2": 0,
+        "measurement_error": 0
+    }
+    total_sub_products_co2 = 0
+
+    # Loop through all sub products
+    for sub in benchmark["sub_products"]:
+        # Get how many of this sub product that we are using
+        amount = sub["unit_amount"]
+
+        # Find the sub product's latest benchmark in the database
+        subby = coll_benchmarks.find_one({"product": sub["product"], "latest_benchmark": True}, {"kg_per_unit": 1})
+
+        # If we couldn't find one, then we set the kg_per_unit to a standard value of 1 kg per unit
+        if not subby:
+            subby = {
+                "kg_per_unit": 1
+            }
+
+        # Get the kg_per_unit from the looked up sub product
+        kg_per_unit = subby["kg_per_unit"]
+
+        # Start calculating the chain impact of the sub product - this is probably already done, so it's fast
+        sub_co2_per_unit = get_chain_impact(sub["product"])
+
+        # Get info about the transport that was used for this sub product
+        trans = coll_transports.find_one({"_id": sub["transport"]})
+
+        # Add the co2 per unit from the sub product's chain impact and multiply by how many we are using
+        total_sub_products_co2 += sub_co2_per_unit * amount
+
+        # Then add the amount of co2 emitted by the transport
+        total_sub_products_co2 += trans["impact"]["co2_per_kg_km"] * amount * kg_per_unit * trans["impact"]["distance_travelled"]
+
+    # Set the co2 in the chain impact to a float with at most 3 decimal points.
+    chain["co2"] = round(benchmark["self_impact"]["co2"] + total_sub_products_co2, 3)
+    return chain
+
+
 # Inserting a benchmark to the database, does not check if it already exists, so make sure to do that before.
 def insert_benchmark(benchmark):
     # Insert benchmark to database
@@ -71,4 +115,46 @@ def insert_benchmark(benchmark):
 
     # Update the newly created benchmark in the database
     coll_benchmarks.update_one({"_id": benchmark["_id"]}, {"$set": { "chain_impact.co2": co2 } } )
+    return benchmark
+
+
+def add_benchmark(benchmark):
+    # We start by creating the chain impact from the specified benchmark without inserting or updating the database
+    chain = create_chain_impact(benchmark)
+
+    # Set necessary fields
+    benchmark["date"] = dt.today().strftime("%Y-%m-%d")
+    benchmark["_id"] = benchmark["product"] + "-" + dt.today().strftime("%Y-%m-%d") + "-" + dt.now().strftime("%H:%M:%S")
+    benchmark["chain_impact"] = chain
+    benchmark["latest_benchmark"] = True
+
+    # Update the old "latest one" to not be latest anymore
+    coll_benchmarks.update_one({"product": benchmark["product"], "latest_benchmark": True }, { "$set": { "latest_benchmark": False } })
+    # Insert the new "latest one".
+    coll_benchmarks.insert_one(benchmark)
+
+    # Lookup all parents of this product and turn it into an iterable list
+    f = coll_benchmarks.find({ "sub_products.product": benchmark["product"], "latest_benchmark": True })
+    parents = list(f)
+
+    # Loop through all parents
+    for parent in parents:
+        
+        # Update this parent to no longer be the latest version of itself
+        coll_benchmarks.update_one({"_id": parent["_id"]}, { "$set": { "latest_benchmark": False } })
+
+        # Create the new benchmark for this parent
+        p_benchmark = {
+            "date": dt.now().strftime("%Y-%m-%d-") + dt.now().strftime("%H:%M:%S"),
+            "_id": parent["product"] + "-" + dt.now().strftime("%Y-%m-%d-") + dt.now().strftime("%H:%M:%S"),
+            "product": parent["product"],
+            "kg_per_unit": parent["kg_per_unit"],
+            "unit": parent["unit"],
+            "self_impact": parent["self_impact"],
+            "sub_products": parent["sub_products"],
+            "latest_benchmark": True
+        }
+
+        # Then recursively add, so we make sure that we update this parent's parents.
+        add_benchmark(p_benchmark)
     return benchmark

--- a/flaskr/bench_util.py
+++ b/flaskr/bench_util.py
@@ -139,7 +139,6 @@ def add_benchmark(benchmark):
 
     # Loop through all parents
     for parent in parents:
-        
         # Update this parent to no longer be the latest version of itself
         coll_benchmarks.update_one({"_id": parent["_id"]}, { "$set": { "latest_benchmark": False } })
 

--- a/flaskr/bench_util.py
+++ b/flaskr/bench_util.py
@@ -5,6 +5,7 @@ from flaskr.db import coll_benchmarks, coll_transports
 import datetime
 import json
 
+
 # Get chain impact for a specific product id using the latest benchmarks for that product.
 def get_chain_impact(_id):
     # Get which product we are trying to find the chain impact for
@@ -23,35 +24,34 @@ def get_chain_impact(_id):
                 amount = sub["unit_amount"]
 
                 # Get that sub product's kg_per_unit and unit
-                subby = coll_benchmarks.find_one({"product": sub["product"], "latest_benchmark": True}, {"kg_per_unit": 1, "unit": 1})
+                subby = coll_benchmarks.find_one({ "product": sub["product"], "latest_benchmark": True }, {"kg_per_unit": 1 })
                 if not subby:
                     subby = {
-                        "unit": "UNDEFINED",
                         "kg_per_unit": 1
                     }
 
                 # Create easier variables for kg_per_unit and unit
-                unit = subby["unit"]
                 kg_per_unit = subby["kg_per_unit"]
 
                 # Recursively get the chain impact of this sub product
                 sub_co2_per_unit = get_chain_impact(sub["product"])
 
                 # Get which transport this sub product has been transported with
-                trans = coll_transports.find_one({"_id": sub["transport"]}) 
+                trans = coll_transports.find_one({"_id": sub["transport"]})
 
                 # Add the co2 emitted by the sub product times how many units of it is used
                 total_sub_products_co2 += sub_co2_per_unit * amount
 
                 # Add the co2 emitted by the transport
-                total_sub_products_co2 += trans["impact"]["co2_per_kg_km"] * amount * kg_per_unit * trans["impact"]["distance_travelled"]
+                trans_co2 = trans["impact"]["co2_per_kg_km"] * amount * kg_per_unit * trans["impact"]["distance_travelled"]
+                total_sub_products_co2 += trans_co2
 
-            #print(f"UPDATING {_id} with CO2: {round(me['self_impact']['co2'] + total_sub_products_co2, 3)}")
-            
-            # When we have summed all sub product's chain impacts, add our own self impact and then update the database with our new chain impact (also does this recursively)
-            coll_benchmarks.update_one({"_id": me['_id'] }, { "$set": { "chain_impact.co2": round(me["self_impact"]["co2"] + total_sub_products_co2, 3) } })       
+            # When we have summed all sub product's chain impacts, add our own self impact and then update the database
+            # with our new chain impact (also does this recursively)
+            new_co2 = round(me["self_impact"]["co2"] + total_sub_products_co2, 3)
+            coll_benchmarks.update_one({"_id": me['_id'] }, { "$set": { "chain_impact.co2": new_co2 } })
 
-            # Also, since we might want the number in other places, return the chain impact co2 here.   
+            # Also, since we might want the number in other places, return the chain impact co2 here.
             return me["self_impact"]["co2"] + total_sub_products_co2
 
         # If we have already calculated the co2 chain impact, then just return it immediately.
@@ -59,6 +59,7 @@ def get_chain_impact(_id):
 
     # If the product does not exists, then return 0 co2.
     return 0
+
 
 # Inserting a benchmark to the database, does not check if it already exists, so make sure to do that before.
 def insert_benchmark(benchmark):
@@ -70,6 +71,4 @@ def insert_benchmark(benchmark):
 
     # Update the newly created benchmark in the database
     coll_benchmarks.update_one({"_id": benchmark["_id"]}, {"$set": { "chain_impact.co2": co2 } } )
-    
     return benchmark
-    

--- a/flaskr/benchmarks.py
+++ b/flaskr/benchmarks.py
@@ -1,9 +1,11 @@
 import flask
 from flask import request, jsonify, make_response
 from flaskr import app, check_payload
-from flaskr.db import coll_benchmarks
+from flaskr.db import coll_benchmarks, coll_products
+from flaskr.bench_util import create_chain_impact, add_benchmark
 import datetime
 import json
+from datetime import datetime as dt
 
 # SEARCH ALL BENCHMARKS FOR PRODUCT
 b_all_sample = {
@@ -112,6 +114,56 @@ def benchmarks_parents():
         else:  # in case the request contains a strange value in key 'search'.
             s = f"Unexpected value '{query['search']}' in key 'search'. Should be either 'latest' or 'all'."
             return make_response(jsonify(s), 400)
+    else:
+        # If the payload doesn't pass payload check, return 400
+        return make_response(jsonify(msg), 400)
+
+
+# SEARCH BENCHMARKS FOR PRODUCT BY DATE
+b_create_sample = {
+    "product": ["str"],
+    "kg_per_unit": ["int", "float"],
+    "unit": ["str"],
+    "self_impact": {
+        "co2": ["int", "float"],
+        "measurement_error": ["float"],
+        "energy_sources": ["list:str"]
+    },
+    "sub_products": [
+        {
+            "product": ["str"],
+            "unit_amount": ["int", "float"],
+            "transport": ["int", "str"]
+        }
+    ]
+}
+"""
+CURL-FRIENDLY TEST:
+$ curl -d '{"product": "accumulator", "kg_per_unit": 2, "unit": "piece", "self_impact": { "co2": 0.15, "measurement_error": 0.02, "energy_sources": ["biogas"] }, "sub_products": [ { "product": "chs-märken", "unit_amount": 25, "transport": 69 }, { "product": "locomotive", "unit_amount": 1, "transport": 42 } ] }' -H "Content-Type: application/json" -X POST http://localhost:5000/benchmarks/create
+"""
+@app.route("/benchmarks/create", methods=["POST"])
+def benchmarks_create():
+    query = request.get_json()  # Get query as json
+    check, msg = check_payload(b_create_sample, query)  # Check payload
+
+    if check:
+        # Make sure that the product you're making a new benchmark for actually exists.
+        if not coll_products.find_one({"_id": query["product"]}):
+            return make_response(jsonify(f"ERROR: No product with ID '{query['product']}' exists."), 404)
+
+        benchmark = {
+            "product": query["product"],
+            "kg_per_unit": query["kg_per_unit"],
+            "unit": query["unit"],
+            "self_impact": {
+                "co2": query["self_impact"]["co2"],
+                "measurement_error": query["self_impact"]["measurement_error"],
+                "energy_sources": [es.lower() for es in query["self_impact"]["energy_sources"]]
+            },
+            "sub_products": query["sub_products"],
+        }
+        b = add_benchmark(benchmark)
+        return make_response(jsonify(b), 200)
     else:
         # If the payload doesn't pass payload check, return 400
         return make_response(jsonify(msg), 400)

--- a/flaskr/benchmarks.py
+++ b/flaskr/benchmarks.py
@@ -15,19 +15,20 @@ $ curl -d '{"product": "accumulator"}' -H "Content-Type: application/json" -X PO
 """
 @app.route("/benchmarks/get/all", methods=["POST"])
 def benchmarks_all():
-    query = request.get_json() # Get query as json
-    check, msg = check_payload(b_all_sample, query) # Check payload
+    query = request.get_json()  # Get query as json
+    check, msg = check_payload(b_all_sample, query)  # Check payload
 
     if check:
-        found = coll_benchmarks.find({'product': query["product"]}) # find all benchmarks for this product
-        l = list(found)
-        if len(l) > 0: # If there are more than 0 found benchmarks, return them
-            return make_response(jsonify(l), 200)
-        else: # if there were no found benchmarks for that product, then return "No benchmarks found"
+        found = coll_benchmarks.find({'product': query["product"]})  # find all benchmarks for this product
+        li = list(found)
+        if len(li) > 0:  # If there are more than 0 found benchmarks, return them
+            return make_response(jsonify(li), 200)
+        else:  # if there were no found benchmarks for that product, then return "No benchmarks found"
             return make_response(jsonify("No benchmarks found."), 404)
     else:
         # If the payload doesn't pass payload check, return 400
         return make_response(jsonify(msg), 400)
+
 
 # SEARCH LATEST BENCHMARK FOR PRODUCT
 b_latest_sample = {
@@ -39,23 +40,24 @@ $ curl -d '{"product": "accumulator"}' -H "Content-Type: application/json" -X PO
 """
 @app.route("/benchmarks/get/latest", methods=["POST"])
 def benchmarks_latest():
-    query = request.get_json() # Get query as json
-    check, msg = check_payload(b_latest_sample, query) # Check payload
+    query = request.get_json()  # Get query as json
+    check, msg = check_payload(b_latest_sample, query)  # Check payload
 
     if check:
-        found = coll_benchmarks.find_one({'product': query["product"], 'latest_benchmark': True}) # find all benchmarks for this product
-        if found: # If there was a benchmark found.
+        found = coll_benchmarks.find_one({'product': query["product"], 'latest_benchmark': True})  # find latest benchmark
+        if found:  # If there was a benchmark found.
             return make_response(jsonify(found), 200)
-        else: # if there was no found benchmark for that product, then return "No benchmark found"
+        else:  # if there was no found benchmark for that product, then return "No benchmark found"
             return make_response(jsonify("No benchmark found."), 404)
     else:
         # If the payload doesn't pass payload check, return 400
         return make_response(jsonify(msg), 400)
 
+
 # SEARCH BENCHMARKS FOR PRODUCT BY DATE
 b_date_sample = {
     "product": ["str"],
-    "date": ["str"] # format 2020-12-06
+    "date": ["str"]  # format 2020-12-06
 }
 """
 CURL-FRIENDLY TEST:
@@ -63,24 +65,25 @@ $ curl -d '{"product": "accumulator", "date": "2020-12-04"}' -H "Content-Type: a
 """
 @app.route("/benchmarks/get/date", methods=["POST"])
 def benchmarks_date():
-    query = request.get_json() # Get query as json
-    check, msg = check_payload(b_date_sample, query) # Check payload
+    query = request.get_json()  # Get query as json
+    check, msg = check_payload(b_date_sample, query)  # Check payload
 
     if check:
-        found = coll_benchmarks.find({'product': query["product"], 'date': query["date"]}) # find all benchmarks for this product
-        l = list(found)
-        if len(l) > 0: # If there was at least one benchmark found.
-            return make_response(jsonify(l), 200)
-        else: # if there were no found benchmarks for that product on that date, then return "No benchmarks found."
+        found = coll_benchmarks.find({'product': query["product"], 'date': query["date"]})  # find dated benchmarks
+        li = list(found)
+        if len(li) > 0:  # If there was at least one benchmark found.
+            return make_response(jsonify(li), 200)
+        else:  # if there were no found benchmarks for that product on that date, then return "No benchmarks found."
             return make_response(jsonify("No benchmarks found."), 404)
     else:
         # If the payload doesn't pass payload check, return 400
         return make_response(jsonify(msg), 400)
 
+
 # SEARCH BENCHMARKS FOR PARENTS OF PRODUCT
 b_parents_sample = {
     "product": ["str"],
-    "search": ["str"] # must be either "latest" or "all".
+    "search": ["str"]  # must be either "latest" or "all".
 }
 """
 CURL-FRIENDLY TEST:
@@ -88,26 +91,27 @@ $ curl -d '{"product": "accumulator", "search": "latest"}' -H "Content-Type: app
 """
 @app.route("/benchmarks/get/parents", methods=["POST"])
 def benchmarks_parents():
-    query = request.get_json() # Get query as json
-    check, msg = check_payload(b_parents_sample, query) # Check payload
+    query = request.get_json()  # Get query as json
+    check, msg = check_payload(b_parents_sample, query)  # Check payload
 
     if check:
         if query["search"] == "latest":
-            found = coll_benchmarks.find({ "sub_products.product": query["product"], "latest_benchmark": True }) # find all latest parent benchmarks for this product
-            l = list(found)
-            if len(l) > 0: # If there was at least one benchmark found.
-                return make_response(jsonify(l), 200)
-            else: # if there were no found benchmarks for that product on that date, then return "No benchmarks found."
+            found = coll_benchmarks.find({ "sub_products.product": query["product"], "latest_benchmark": True })
+            li = list(found)
+            if len(li) > 0:  # If there was at least one benchmark found.
+                return make_response(jsonify(li), 200)
+            else:  # if there were no found benchmarks for that product on that date, then return "No benchmarks found."
                 return make_response(jsonify("No benchmarks found."), 404)
         elif query["search"] == "all":
-            found = coll_benchmarks.find({ "sub_products.product": query["product"] }) # find all parent benchmarks for this product.
-            l = list(found)
-            if len(l) > 0: # If there was at least one benchmark found.
-                return make_response(jsonify(l), 200)
-            else: # if there were no found benchmarks for that product on that date, then return "No benchmarks found."
+            found = coll_benchmarks.find({ "sub_products.product": query["product"] })  # find all parent benchmarks
+            li = list(found)
+            if len(li) > 0:  # If there was at least one benchmark found.
+                return make_response(jsonify(li), 200)
+            else:  # if there were no found benchmarks for that product on that date, then return "No benchmarks found."
                 return make_response(jsonify("No benchmarks found."), 404)
-        else: # in case the request contains a strange value in key 'search'.
-            return make_response(jsonify(f"Unexpected value '{query['search']}' in key 'search'. Should be either 'latest' or 'all'."), 400)
+        else:  # in case the request contains a strange value in key 'search'.
+            s = f"Unexpected value '{query['search']}' in key 'search'. Should be either 'latest' or 'all'."
+            return make_response(jsonify(s), 400)
     else:
         # If the payload doesn't pass payload check, return 400
         return make_response(jsonify(msg), 400)

--- a/flaskr/db.py
+++ b/flaskr/db.py
@@ -1,9 +1,8 @@
 import pymongo
 import config
 
-client = pymongo.MongoClient(config.get_setting("mongodb-connection-string"),ssl=True,ssl_cert_reqs="CERT_NONE")
+client = pymongo.MongoClient(config.get_setting("mongodb-connection-string"), ssl=True, ssl_cert_reqs="CERT_NONE")
 db = client.testing
 coll_products = db.test
 coll_benchmarks = db.bench
 coll_transports = db.trans
-

--- a/flaskr/products.py
+++ b/flaskr/products.py
@@ -16,20 +16,20 @@ Following sample object conventions.
  - keys with objects are recursively checked with the above two rules
 """
 product_create_sample = {
-    '_id': ["str"], # e.g. "IKEA-BILLY-5"
-    'type': "product", # will always be product
-    'tags': ["list:str"], # e.g. ["furniture", "shelf", "wood"]
-    'type_description': ["str"], # "Assembly"
-    'prod_name': ["str"], # e.g. "Billy Shelf"
-    'kg_per_unit': ["float", "int"], # e.g. 12.81
+    '_id': ["str"],  # e.g. "IKEA-BILLY-5"
+    'type': "product",  # will always be product
+    'tags': ["list:str"],  # e.g. ["furniture", "shelf", "wood"]
+    'type_description': ["str"],  # "Assembly"
+    'prod_name': ["str"],  # e.g. "Billy Shelf"
+    'kg_per_unit': ["float", "int"],  # e.g. 12.81
     'unit': ["str"],
     'benchmark': {
         "self_impact": {
-            "co2": ["float", "int"], # e.g. 292.62
-            "measurement_error": ["float"], # e.g. 0.05 -> 5% error margin
-            "energy_sources": ["list:str"] # e.g. ["Solar", "Nuclear", "Wind"]
+            "co2": ["float", "int"],  # e.g. 292.62
+            "measurement_error": ["float"],  # e.g. 0.05 -> 5% error margin
+            "energy_sources": ["list:str"]  # e.g. ["Solar", "Nuclear", "Wind"]
         },
-        "date": ["str"], # e.g. "2020-11-30-22:50:51"
+        "date": ["str"],  # e.g. "2020-11-30-22:50:51"
         "sub_products": [
             {
                 "product": ["str"],
@@ -43,7 +43,7 @@ product_create_sample = {
 CURL-FRIENDLY TEST:
 $ curl -X POST -d '{ "_id": "IKEA-BILLY", "kg_per_unit": 25, "unit": "piece", "type": "product", "tags": ["Furniture"], "type_description": "Assembly", "prod_name": "IKEA Billy Shelf", "benchmark": { "self_impact": { "co2": 5.1, "measurement_error": 0.05, "energy_sources": ["Solar", "Nuclear", "Wind"] }, "date": "2020-12-01-00:05:32", "sub_products": [] } }' -H "Content-Type: application/json" 127.0.0.1:5000/products/create
 """
-@app.route('/products/create', methods=["POST"]) 
+@app.route('/products/create', methods=["POST"])
 def products_create():
     query = request.get_json()
     check, msg = check_payload(product_create_sample, query)
@@ -59,8 +59,7 @@ def products_create():
 
         find = coll_products.find_one({'_id': query['_id'].upper()})
         # If find returns the product, we do none of the below (product already exists)
-        
-        if find == None:
+        if find is None:
             coll_products.insert_one(prod)
 
             benchmark = {
@@ -101,17 +100,16 @@ $ curl -X POST -d '{ "tags": ["iron", "green"] }' -H "Content-Type: application/
 """
 @app.route('/products/search/tags', methods=["POST"])
 def products_search_by_tag():
-    query = request.get_json() # get query in json-format
+    query = request.get_json()  # get query in json-format
     succ, msg = check_payload(product_search_sample_tags, query)
 
     if succ:
-        coll_products.create_index('tags') # create tag-index
-        found = coll_products.find({'tags': { '$all': query['tags']}}) # find products which have ALL the specified tags
-        l = list(found)
-        if len(l) == 0:
+        coll_products.create_index('tags')  # create tag-index
+        found = coll_products.find({'tags': { '$all': query['tags']}})  # find products which have ALL the specified tags
+        li = list(found)
+        if len(li) == 0:
             return make_response(jsonify("No products found."), 404)
-        return make_response(jsonify(l), 200)
-    
+        return make_response(jsonify(li), 200)
     return make_response(jsonify(msg), 400)
 
 
@@ -125,18 +123,14 @@ $ curl -X POST -d '{ "_id": ["accumulator", "steel-axe"] }' -H "Content-Type: ap
 """
 @app.route('/products/search/id', methods=["POST"])
 def products_search_by_id():
-    query = request.get_json() # get query in json-format
+    query = request.get_json()  # get query in json-format
     succ, msg = check_payload(product_search_sample_id, query)
 
     if succ:
-        found = coll_products.find({'_id': {'$in': query['_id']}}) # find products with any of the id's provided
-        l = (list(found))
-        if len(l) == 0: # if none found, return error
+        found = coll_products.find({'_id': {'$in': query['_id']}})  # find products with any of the id's provided
+        li = (list(found))
+        if len(li) == 0:  # if none found, return error
             return make_response(jsonify("No products found."), 404)
-        return make_response(jsonify(l), 200)
+        return make_response(jsonify(li), 200)
 
     return make_response(jsonify(msg), 400)
-
-
-
-

--- a/flaskr/products.py
+++ b/flaskr/products.py
@@ -18,7 +18,7 @@ Following sample object conventions.
 product_create_sample = {
     '_id': ["str"], # e.g. "IKEA-BILLY-5"
     'type': "product", # will always be product
-    'tags': ["list"], # e.g. ["furniture", "shelf", "wood"]
+    'tags': ["list:str"], # e.g. ["furniture", "shelf", "wood"]
     'type_description': ["str"], # "Assembly"
     'prod_name': ["str"], # e.g. "Billy Shelf"
     'kg_per_unit': ["float", "int"], # e.g. 12.81
@@ -27,10 +27,16 @@ product_create_sample = {
         "self_impact": {
             "co2": ["float", "int"], # e.g. 292.62
             "measurement_error": ["float"], # e.g. 0.05 -> 5% error margin
-            "energy_sources": ["list"] # e.g. ["Solar", "Nuclear", "Wind"]
+            "energy_sources": ["list:str"] # e.g. ["Solar", "Nuclear", "Wind"]
         },
         "date": ["str"], # e.g. "2020-11-30-22:50:51"
-        "sub_products": ["list"],# should be a list of objects with "product" and "transport" keys
+        "sub_products": [
+            {
+                "product": ["str"],
+                "unit_amount": ["float", "int"],
+                "transport": ["int"]
+            }
+        ]
     }
 }
 """
@@ -87,7 +93,7 @@ def products_create():
 
 # SEARCH PRODUCTS BY TAGS
 product_search_sample_tags = {
-    "tags": ["list"],
+    "tags": ["list:str"],
 }
 """
 CURL-FRIENDLY TEST:
@@ -111,7 +117,7 @@ def products_search_by_tag():
 
 # SEARCH PRODUCTS BY ID'S
 product_search_sample_id = {
-    "_id": ["list"],
+    "_id": ["list:str"],
 }
 """
 CURL-FRIENDLY TEST:

--- a/flaskr/transports.py
+++ b/flaskr/transports.py
@@ -22,7 +22,7 @@ transport_create_sample = {
         'co2_per_kg_km': ['int', 'float'],
         'measurement_error': ['int', 'float'],
         'distance_travelled': ['int', 'float'],
-        'energy_sources': ['list'],
+        'energy_sources': ['list:str'],
     },
     'start_lat': ["float", "int"],
     'start_lon': ["float", "int"],
@@ -56,7 +56,7 @@ def transports_create():
 
 # SEARCH TRANSPORTS BY ID'S
 transport_search_sample_id = {
-    "_id": ["list"],
+    "_id": ["list:int"],
 }
 
 """

--- a/flaskr/transports.py
+++ b/flaskr/transports.py
@@ -15,9 +15,9 @@ Following sample object conventions.
  - keys with objects are recursively checked with the above two rules
 """
 transport_create_sample = {
-    '_id': ["int"], # e.g. 1
-    'type': "transport", # will always be transport
-    'type_description': ["str"], # e.g. "train"
+    '_id': ["int"],  # e.g. 1
+    'type': "transport",  # will always be transport
+    'type_description': ["str"],  # e.g. "train"
     'impact': {
         'co2_per_kg_km': ['int', 'float'],
         'measurement_error': ['int', 'float'],
@@ -35,7 +35,6 @@ transport_create_sample = {
 CURL-FRIENDLY TEST:
 $ curl -X POST -d '{ "_id": 100, "type": "transport", "type_description": "train", "impact": {"co2_per_kg_km":0.005, "measurement_error": 0.11, "distance_travelled": 14000, "energy_sources":["nuclear", "coal"]}, "start_lat": 27.19, "start_lon": 113.69, "end_lat": 27.49, "end_lon": 119.66, "max_weight": 3219}' -H "Content-Type: application/json" 127.0.0.1:5000/transports/create
 """
-
 @app.route('/transports/create', methods=['POST'])
 def transports_create():
     query = request.get_json()
@@ -44,13 +43,13 @@ def transports_create():
         # Check whether transport id already exists in DB
         find = coll_transports.find_one({'_id': query['_id']})
         # We add the transport if the id doesn't exist in DB
-        if find == None:
+        if find is None:
             coll_transports.insert_one(query)
             return make_response(jsonify(query), 200)
         else:
             return make_response(jsonify('ERROR: ID ' + str(query['_id']) + ' already exists'), 400)
     else:
-        # Something went wrong when checking payload. Return error. 
+        # Something went wrong when checking payload. Return error.
         return make_response(jsonify(msg), 400)
 
 
@@ -63,20 +62,16 @@ transport_search_sample_id = {
 CURL-FRIENDLY TEST:
 $ curl -X POST -d '{ "_id": [1,2] }' -H "Content-Type: application/json" 127.0.0.1:5000/transports/search/id
 """
-
 @app.route('/transports/search/id', methods=['POST'])
 def transports_get_id():
     query = request.get_json()
     succ, msg = check_payload(transport_search_sample_id, query)
 
     if succ:
-        found = coll_transports.find({'_id': {'$in': query['_id']}}) # find transports with any of the id's provided
-        l = (list(found))
-        if len(l) == 0: # if none found, return error
+        found = coll_transports.find({'_id': {'$in': query['_id']}})  # find transports with any of the id's provided
+        li = (list(found))
+        if len(li) == 0:  # if none found, return error
             return make_response(jsonify("No transports found."), 404)
-        return make_response(jsonify(l), 200)
+        return make_response(jsonify(li), 200)
 
     return make_response(jsonify(msg), 400)
-
-
-


### PR DESCRIPTION
### Added new endpoint CREATE NEW BENCHMARK fix #11 
We have finally arrived. The endpoint we've been waiting for is finally here and it works like a charm. You can use /benchmarks/create to create a new benchmark for a product. This new benchmark will be marked as the *latest* one, and all other benchmarks that reference this newly updated benchmark will also get updated with new benchmarks! It's lovely. Recursion was used to traverse upwards in the tree.

### Fixed syntax problems
I installed a flake8 linter which is used when we check the code for errors during PR's. So I made sure that the code has as few of those linting errors as possible, super nice.

### Fixed payload checking fix #23
Before, if payloads were said to contain lists of elements, then we didn't type check those elements. NOW WE DO! I've made the type checker even better and it checks for the correct element type (IT EVEN WORKS FOR LISTS OF OBJECTS HOLY MACARONI).